### PR TITLE
Implement support for raw file content streaming.

### DIFF
--- a/client/src/it/scala/giterrific/ClientSpec.scala
+++ b/client/src/it/scala/giterrific/ClientSpec.scala
@@ -7,6 +7,7 @@ import org.scalatest._
 import org.scalatest.RecoverMethods._
 import net.liftweb.json._
 import net.liftweb.json.Extraction._
+import scala.io.Source
 
 trait ClientSpec[ReqType <: HttpReq[ReqType]] extends AsyncFeatureSpec with GivenWhenThen {
   implicit val formats = DefaultFormats
@@ -155,6 +156,41 @@ trait ClientSpec[ReqType <: HttpReq[ReqType]] extends AsyncFeatureSpec with Give
     scenario("Refers to a valid ref with an invalid file specified") {
       recoverToSucceededIf[java.util.concurrent.ExecutionException] {
         testClient.repo("test.git").withRef("master").withPath("foobar.txt").getContents()
+      }
+    }
+  }
+
+  feature("Retrieving raw files") {
+    scenario("Refers to an invalid repository") {
+      recoverToSucceededIf[java.util.concurrent.ExecutionException] {
+        testClient.repo("foobar").withRef("master").withPath("hello.txt").getRaw()
+      }
+    }
+
+    scenario("Refers to an invalid ref") {
+      recoverToSucceededIf[java.util.concurrent.ExecutionException] {
+        testClient.repo("test.git").withRef("foobar").withPath("hello.txt").getRaw()
+      }
+    }
+
+    scenario("Refers to a valid ref without a file specified") {
+      recoverToSucceededIf[java.lang.IllegalStateException] {
+        testClient.repo("test.git").withRef("foobar").getRaw()
+      }
+    }
+
+    scenario("Refers to a valid ref with a valid file specified") {
+      testClient.repo("test.git").withRef("master").withPath("hello.txt").getRaw().map { result =>
+        val resultString = Source.fromInputStream(result).mkString
+        result.close()
+
+        assert("hello mom\\n\n" == resultString)
+      }
+    }
+
+    scenario("Refers to a valid ref with an invalid file specified") {
+      recoverToSucceededIf[java.util.concurrent.ExecutionException] {
+        testClient.repo("test.git").withRef("master").withPath("foobar.txt").getRaw()
       }
     }
   }

--- a/client/src/main/scala/giterrific/driver/http/DispatchHttpDriver.scala
+++ b/client/src/main/scala/giterrific/driver/http/DispatchHttpDriver.scala
@@ -16,6 +16,8 @@
  */
 package giterrific.driver.http
 
+import com.ning.http.client.Response
+import java.io.InputStream
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
@@ -40,5 +42,20 @@ case class DispatchHttpDriver() extends HttpDriver[DispatchHttpReq] {
 
   def run(request: DispatchHttpReq)(implicit ec: ExecutionContext): Future[String] = {
     dispatch.Http(request.underlyingReq OK dispatch.as.String)
+  }
+
+  def runRaw(request: DispatchHttpReq)(implicit ec: ExecutionContext): Future[InputStream] = {
+    dispatch.Http(request.underlyingReq).flatMap { result =>
+      if (result.getStatusCode() == 200) {
+        Future.successful(result.getResponseBodyAsStream())
+      } else {
+        val statusCode = result.getStatusCode()
+        val body = result.getResponseBody()
+
+        Future.failed(new RuntimeException(
+          "Got status code $statusCode and response: $body"
+        ))
+      }
+    }
   }
 }

--- a/client/src/main/scala/giterrific/driver/http/DispatchHttpDriver.scala
+++ b/client/src/main/scala/giterrific/driver/http/DispatchHttpDriver.scala
@@ -17,6 +17,7 @@
 package giterrific.driver.http
 
 import com.ning.http.client.Response
+import java.util.concurrent.ExecutionException
 import java.io.InputStream
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -52,8 +53,8 @@ case class DispatchHttpDriver() extends HttpDriver[DispatchHttpReq] {
         val statusCode = result.getStatusCode()
         val body = result.getResponseBody()
 
-        Future.failed(new RuntimeException(
-          "Got status code $statusCode and response: $body"
+        Future.failed(new ExecutionException(
+          new RuntimeException("Got status code $statusCode and response: $body")
         ))
       }
     }

--- a/client/src/main/scala/giterrific/driver/http/HttpDriver.scala
+++ b/client/src/main/scala/giterrific/driver/http/HttpDriver.scala
@@ -16,6 +16,7 @@
  */
 package giterrific.driver.http
 
+import java.io.InputStream
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
@@ -37,5 +38,6 @@ trait HttpReq[UnderlyingType <: HttpReq[UnderlyingType]] {
  */
 trait HttpDriver[ReqType <: HttpReq[_]] {
   def run(request: ReqType)(implicit ec: ExecutionContext): Future[String]
+  def runRaw(request: ReqType)(implicit ec: ExecutionContext): Future[InputStream]
   def url(url: String): ReqType
 }

--- a/extras/playws24/src/main/scala/giterrific/driver/http/WS24HttpDriver.scala
+++ b/extras/playws24/src/main/scala/giterrific/driver/http/WS24HttpDriver.scala
@@ -17,8 +17,10 @@
 
 package giterrific.driver.http
 
+import java.io.InputStream
 import java.util.concurrent.ExecutionException
 import play.api.libs.ws._
+import play.api.libs.ws.ning._
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
@@ -60,6 +62,28 @@ case class WS24HttpDriver(wsClient: WSClient) extends HttpDriver[WS24HttpReq] {
     underlyingRequest.get().flatMap { response =>
       if (response.status == 200) {
         Future.successful(response.body)
+      } else {
+        Future.failed(new ExecutionException(s"Upstream returned ${response.status} for request.", new RuntimeException(response.body)))
+      }
+    }
+  }
+
+  def runRaw(request: WS24HttpReq)(implicit ec: ExecutionContext): Future[InputStream] = {
+    val underlyingRequest = wsClient.url(request.url)
+      .withHeaders(request.headers.toSeq: _*)
+      .withQueryString(request.headers.toSeq: _*)
+
+    underlyingRequest.get().flatMap { response =>
+      if (response.status == 200) {
+        response match {
+          case ningResponse: NingWSResponse =>
+            Future.successful(ningResponse.ahcResponse.getResponseBodyAsStream())
+
+          case unknownResponse =>
+            Future.failed(new ExecutionException(
+              new RuntimeException("Got an unknown type of WSResponse. Needed NingWSResponse.")
+            ))
+        }
       } else {
         Future.failed(new ExecutionException(s"Upstream returned ${response.status} for request.", new RuntimeException(response.body)))
       }


### PR DESCRIPTION
This PR adds support for retrieving raw file content from the Giterrific server.

Certain files are much too large to retrieve their content as a JSON object with a few parameters in it. Giterrific's underlying implementation will actually _refuse_ to let us read the entire thing into memory at once! So, to support retrieving those files, we have the ability to surface the entire result as a stream from the server. Now, our Scala language bindings have the ability to retrieve those streams directly.

Closes #4.
