### PR TITLE
Commit counting

### DIFF
--- a/client/src/it/scala/giterrific/ClientSpec.scala
+++ b/client/src/it/scala/giterrific/ClientSpec.scala
@@ -32,26 +32,32 @@ trait ClientSpec[ReqType <: HttpReq[ReqType]] extends AsyncFeatureSpec with Give
 
     scenario("Refers to a valid ref") {
       val expectedJson = """
-      |[
-      |  {
-      |    "sha":"558faad4023f2690e35c8fd234666408223a4301",
-      |    "author":{
-      |      "date":"2016-08-20T19:44:35Z",
-      |      "name":"Matt Farmer",
-      |      "email":"matt@frmr.me"
-      |    },
-      |    "committer":{
-      |      "date":"2016-08-20T19:44:35Z",
-      |      "name":"Matt Farmer",
-      |      "email":"matt@frmr.me"
-      |    },
-      |    "message":"Initial checking\n"
-      |  }
-      |]
+      |{
+      |  "ref": "master",
+      |  "skip": 0,
+      |  "maxCount": 20,
+      |  "totalCommitCount": 1,
+      |  "commits": [
+      |    {
+      |      "sha":"558faad4023f2690e35c8fd234666408223a4301",
+      |      "author":{
+      |        "date":"2016-08-20T19:44:35Z",
+      |        "name":"Matt Farmer",
+      |        "email":"matt@frmr.me"
+      |      },
+      |      "committer":{
+      |        "date":"2016-08-20T19:44:35Z",
+      |        "name":"Matt Farmer",
+      |        "email":"matt@frmr.me"
+      |      },
+      |      "message":"Initial checking\n"
+      |    }
+      |  ]
+      |}
       |""".stripMargin
 
       testClient.repo("test.git").withRef("master").getCommits().map { result =>
-        assert(parse(expectedJson).extract[List[RepositoryCommitSummary]] == result)
+        assert(parse(expectedJson).extract[RepositoryCommitSummaryPage] == result)
       }
     }
   }

--- a/client/src/main/scala/giterrific/client/GiterrificRequester.scala
+++ b/client/src/main/scala/giterrific/client/GiterrificRequester.scala
@@ -131,8 +131,8 @@ class GiterrificRequester[ReqType <: HttpReq[ReqType]](
    * @param skip The number of commits to skip when generating the summary. Defaults to 0.
    * @param maxCount The number of commits to return when generating the summary. Defaults to 20.
    */
-  def getCommits(skip: Int = 0, maxCount: Int = 20): Future[List[RepositoryCommitSummary]] = {
-    run[List[RepositoryCommitSummary]](baseRequest.withQuery(Map(
+  def getCommits(skip: Int = 0, maxCount: Int = 20): Future[RepositoryCommitSummaryPage] = {
+    run[RepositoryCommitSummaryPage]  (baseRequest.withQuery(Map(
       "skip" -> skip.toString,
       "maxCount" -> maxCount.toString
     )))

--- a/core/src/main/scala/giterrific/core/RepositoryCommitSummary.scala
+++ b/core/src/main/scala/giterrific/core/RepositoryCommitSummary.scala
@@ -50,3 +50,22 @@ case class RepositoryCommitSummary(
   committer: RepositoryCommitIdentity,
   message: String
 )
+
+/**
+ * A data structure representing a page of commits from the repository.
+ *
+ * @param ref The ref that this commit summary page is browsing.
+ * @param totalCommitCount The total number of commits on this ref.
+ * @param skip The number of commits skipped before the beginning of this page.
+ * @param maxCount The maximum number of commits that could be in this page.
+ * @param commits The commits for this page.
+ */
+case class RepositoryCommitSummaryPage(
+  ref: String,
+  totalCommitCount: Int,
+  skip: Int,
+  maxCount: Int,
+  commits: List[RepositoryCommitSummary]
+) {
+  def length = commits.length
+}

--- a/server/src/main/scala/giterrific/api/ApiV1.scala
+++ b/server/src/main/scala/giterrific/api/ApiV1.scala
@@ -17,6 +17,7 @@
 package giterrific
 package api
 
+import giterrific.core._
 import giterrific.git._
 import giterrific.git.JGitWrappers._
 import giterrific.server.BuildInfo
@@ -64,7 +65,15 @@ object ApiV1 extends RestHelper with Loggable {
               ref <- getRef(repo, commitRef)
               commit <- getCommit(revwalk, ref)
             } yield {
-              decompose(toCommitSummary(revwalk, commit, skip, maxCount))
+              val commits = toCommitSummary(revwalk, commit, skip, maxCount)
+
+              decompose(RepositoryCommitSummaryPage(
+                ref = commitRef,
+                totalCommitCount = countCommitsInTree(revwalk, commit),
+                skip = skip,
+                maxCount = maxCount,
+                commits = commits.toList
+              ))
             }
           }
 

--- a/server/src/main/scala/giterrific/git/JGitWrappers.scala
+++ b/server/src/main/scala/giterrific/git/JGitWrappers.scala
@@ -153,6 +153,19 @@ object JGitWrappers {
   }
 
   /**
+   * Count the total number of commits in a tree, the head of which should be identified by
+   * startCommit. This method will reset the walker after it's calculated the number of commits.
+   *
+   * @param walker The rev walker that you'd like to navigate in.
+   * @param startCommit the HEAD from which to start counting commits.
+   */
+  def countCommitsInTree(walker: RevWalk, startCommit: RevCommit): Int = {
+    val numberOfCommits = RevWalkUtils.count(walker, startCommit, null)
+    walker.reset()
+    numberOfCommits
+  }
+
+  /**
    * Generate a commit summary for a repository. This method includes built in support for
    * pagination by way of "skip" and "maxCount".
    *


### PR DESCRIPTION
This changes the data structure we return for the commit list request so that it surfaces enough data for calling code to make smart predictions about when they will reach the end of the commit pagination. It also might be interesting for calling code to surface the total number of commits in the repo.

Closes #6 
