### PR TITLE
Finicky Finagle: Implement a Finagle HTTP driver package.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ branches:
   only:
   - master
 
-script: sbt client/it:test playws24/it:test
+script: sbt client/it:test playws24/it:test finagle/it:test
 
 cache:
   directories:

--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,12 @@ lazy val playws24 =
     .settings(Defaults.itSettings: _*)
     .dependsOn(client % "compile->compile;it->it")
 
+lazy val finagle =
+  (project in file("extras/finagle"))
+    .configs(IntegrationTest)
+    .settings(Defaults.itSettings: _*)
+    .dependsOn(client % "compile->compile;it->it")
+
 lazy val giterrific =
   (project in file("."))
     .settings(unidocSettings: _*)

--- a/extras/finagle/build.sbt
+++ b/extras/finagle/build.sbt
@@ -1,0 +1,42 @@
+name := "giterrific-finagle"
+
+organization := "me.frmr.giterrific.extras"
+
+version := GiterrificKeys.version
+
+scalaVersion := GiterrificKeys.primaryScalaVersion
+
+scalacOptions ++= GiterrificKeys.defaultScalacOptions
+
+publishTo <<= version { (v: String) =>
+  val nexus = "https://oss.sonatype.org/"
+  if (v.trim.endsWith("SNAPSHOT"))
+    Some("Sonatype Snapshots" at nexus + "content/repositories/snapshots")
+  else
+    Some("Sonatype Releases"  at nexus + "service/local/staging/deploy/maven2")
+}
+
+credentials += Credentials(Path.userHome / ".sonatype")
+
+libraryDependencies += "com.twitter" %% "finagle-http" % "6.38.0" % "provided"
+
+pomExtra :=
+<url>https://github.com/farmdawgnation/giterrific</url>
+<licenses>
+  <license>
+    <name>Apache 2</name>
+    <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    <distribution>repo</distribution>
+  </license>
+</licenses>
+<scm>
+  <url>https://github.com/farmdawgnation/giterrific.git</url>
+  <connection>https://github.com/farmdawgnation/giterrific.git</connection>
+</scm>
+<developers>
+  <developer>
+    <id>farmdawgnation</id>
+    <name>Matt Farmer</name>
+    <email>matt@frmr.me</email>
+  </developer>
+</developers>

--- a/extras/finagle/src/it/scala/giterrific/FinagleClientSpec.scala
+++ b/extras/finagle/src/it/scala/giterrific/FinagleClientSpec.scala
@@ -1,0 +1,26 @@
+/**
+ *
+ * Copyright 2016 Matthew Farmer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package giterrific
+
+import giterrific.client._
+import giterrific.driver.http._
+import org.scalatest._
+
+class FinagleClientSpec extends ClientSpec[FinagleHttpReq] with BeforeAndAfterAll {
+  val driver = FinagleHttpDriver()
+  override val testClient = new GiterrificClient("http://localhost:8080", driver)
+}

--- a/extras/finagle/src/main/scala/giterrific/driver/http/FinagleHttpDriver.scala
+++ b/extras/finagle/src/main/scala/giterrific/driver/http/FinagleHttpDriver.scala
@@ -1,0 +1,100 @@
+/**
+ *
+ * Copyright 2016 Matthew Farmer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package giterrific.driver.http
+
+import com.twitter.finagle._
+import java.io.InputStream
+import java.net.URL
+import java.util.concurrent.ExecutionException
+import scala.concurrent.{ExecutionContext, Future, Promise}
+
+/**
+ * A data structure representing a request that will be used with Finagle's HTTP library.
+ *
+ * @param url The URL to issue the request to.
+ * @param headers The headers to use for the request.
+ * @param query The query string parameters for the request.
+ */
+case class FinagleHttpReq(
+  url: String,
+  headers: Map[String, String] = Map.empty,
+  query: Map[String, String] = Map.empty
+) extends HttpReq[FinagleHttpReq] {
+  def withHeaders(headers: Map[String, String]): FinagleHttpReq =
+    copy(headers = this.headers ++ headers)
+
+  def withQuery(query: Map[String, String]): FinagleHttpReq =
+    copy(query = this.query ++ query)
+
+  def /(urlPart: String): FinagleHttpReq =
+    copy(url = this.url + "/" + urlPart)
+}
+
+/**
+ * An implementation of Giterrific's HttpDriver abstraction driven by Finagle.
+ */
+case class FinagleHttpDriver() extends HttpDriver[FinagleHttpReq] {
+  def url(url: String) = FinagleHttpReq(url)
+
+  def run(request: FinagleHttpReq)(implicit ec: ExecutionContext): Future[String] = {
+    val generatedUrl = if (request.query == Map.empty) {
+      request.url
+    } else {
+      request.url + "?" + request.query.toList.map {
+        case (key, value) =>
+          "$key=$value"
+      }.mkString("&")
+    }
+
+    val parsedUrl = new URL(generatedUrl)
+    val initialBuilder = http.RequestBuilder().url(parsedUrl)
+    val builderWithHeaders = request.headers.toList.foldLeft(initialBuilder) { (currentBuilder, header) =>
+      currentBuilder.setHeader(header._1, header._2)
+    }
+    val finalRequest = builderWithHeaders.buildGet()
+
+    val hostname = parsedUrl.getHost()
+    val port = if (parsedUrl.getPort() == -1) {
+      parsedUrl.getDefaultPort()
+    } else {
+      parsedUrl.getPort()
+    }
+    val client = Http.newService(s"$hostname:$port")
+
+    val resultPromise = Promise[http.Response]()
+    val twitterFuture = client(finalRequest)
+    twitterFuture.respond(twitterTry => resultPromise.complete(twitterTry.asScala))
+    val resultFuture = resultPromise.future
+
+    resultFuture.flatMap { httpResponse =>
+      if (httpResponse.statusCode == 200) {
+        Future.successful(httpResponse.getContentString())
+      } else {
+        Future.failed(new ExecutionException(
+          new RuntimeException(
+            s"Server returned ${httpResponse.statusCode} with response: ${httpResponse.getContentString}"
+          )
+        ))
+      }
+    }
+  }
+
+  def runRaw(request: FinagleHttpReq)(implicit ec: ExecutionContext): Future[InputStream] = {
+    Future.failed(new IllegalStateException("boo!"))
+  }
+}


### PR DESCRIPTION
This implements support for using [Finagle](https://twitter.github.io/finagle/) as the underlying Giterrific Client's HTTP driver. In further support of our pluggable dependency pattern we want to meet consumers of the library "where they're at." If Finagle is their preferred HTTP implementation that they're already pulling in, then they should be able to pull in this package in addition to Giterrific instead of having to add Databinder Dispatch to their list of dependencies.

Closes #5.
